### PR TITLE
Fix broken headings in Markdown files

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,7 +61,7 @@ $ dsdownload --output my-images --workers 2 https://github.com/DiSiqueira/DSDown
 ## Module Usage
 The module allows you to download url lists in your own Python programs without going through the command line. Here's an example of it's usage:
 
-###Example
+### Example
 ```python
 from DSDownload import DSDownload
 


### PR DESCRIPTION
GitHub changed the way Markdown headings are parsed, so this change fixes it.

See [bryant1410/readmesfix](https://github.com/bryant1410/readmesfix) for more information.

Tackles bryant1410/readmesfix#1
